### PR TITLE
fix deprecation warnings

### DIFF
--- a/source/bloch.jl
+++ b/source/bloch.jl
@@ -54,7 +54,7 @@ type Bloch
     view_elevation::Float64
     view_azimuth::Float64
     elements::Vector{Element} # our points/vectors
-    colors::Vector{ASCIIString}
+    colors::Vector{String}
 end
 
 # Standard Initialization
@@ -118,9 +118,9 @@ function render(b::Bloch,rotate_z = 0)
     u = linspace(0,2*π,n);
     v = linspace(0,π,n);
 
-    x = cos(u) * sin(v)';
-    y = sin(u) * sin(v)';
-    z = ones(n) * cos(v)';
+    x = cos.(u) * sin.(v)';
+    y = sin.(u) * sin.(v)';
+    z = ones(n) * cos.(v)';
 
     # Sphere surface
     surf(x,y,z, rstride=1, cstride=1, color=b.sphere_color, linewidth=0, shade=true)
@@ -129,8 +129,8 @@ function render(b::Bloch,rotate_z = 0)
     mesh(x,y,z, rstride=10, cstride=6, color=b.mesh_color)
 
     # plot equator
-    plot( cos(u), sin(u), zs=0, color=b.equator_color, linewidth= 1 ) 
-    plot( cos(u), sin(u), zs=0, zdir="x", color=b.equator_color, linewidth= 1 ) 
+    plot( cos.(u), sin.(u), zs=0, color=b.equator_color, linewidth= 1 )
+    plot( cos.(u), sin.(u), zs=0, zdir="x", color=b.equator_color, linewidth= 1 )
 
     # plot xyz bloch sphere axis
     span = linspace(-1,1,2)

--- a/source/func.jl
+++ b/source/func.jl
@@ -29,13 +29,13 @@ function ket_to_bloch(ket::Array, digits = 3)
     v_x = α*conj(β) + conj(α)*β  # = 2Re(α*conj(β))
     v_y = im*α*conj(β) - im*conj(α)*β # = -2Re(α*conj(β))
     v_z = α*conj(α) - β*conj(β)
-    return round(real([v_x,v_y,v_z]),digits)
+    return round.(real([v_x,v_y,v_z]),digits)
 end
 
 function ket_to_bloch(α::Number,β::Number, digits = 3)
     v_x = α*conj(β) + conj(α)*β  # = 2Re(α*conj(β))
     v_y = im*α*conj(β) - im*conj(α)*β # = -2Re(α*conj(β))
     v_z = α*conj(α) - β*conj(β)
-    return round(real([v_x,v_y,v_z]),digits)
+    return round.(real([v_x,v_y,v_z]),digits)
 end
 


### PR DESCRIPTION
support Julia v0.5 and v0.6.
Julia v0.4 is too old to use. Latest [JuliaBox](https://next.juliabox.com/) does not support julia v0.4.